### PR TITLE
chore: add NtoLib FB authoring skills

### DIFF
--- a/.claude/skills/make-release/SKILL.md
+++ b/.claude/skills/make-release/SKILL.md
@@ -1,9 +1,11 @@
 ---
-name: release
-description: Use this skill when the user asks to release a new NtoLib version — "let's release v1.12.0", "cut a release", "выпустить новую версию", "пуш тега", "сделать beta1". Walks through gathering changes since the last release, drafting release notes in the project's established Russian style, creating an annotated tag with the right cleanup flag, pushing it to trigger the GitHub Actions release workflow, and verifying the published GitHub Release.
+name: make-release
+description: Use this skill when the user asks to release a new NtoLib version — "let's release v1.12.0", "cut a release", "выпустить новую версию", "пуш тега", "сделать beta1". Walks through gathering changes since the last release, drafting release notes in the project's established Russian style, creating an annotated tag with the right cleanup flag, pushing it to trigger the GitHub Actions release workflow, and verifying the published GitHub Release. NOT for generic release tooling on other repos (use release-tools:new) or for listing unreleased commits (use release-tools:last-tag).
 ---
 
 # Releasing a new NtoLib version
+
+Cut and publish a tagged NtoLib release end to end: gather changes, draft Russian release notes, create the annotated tag, push to trigger CI, and verify the published GitHub Release.
 
 The release flow is fully automated by `.github/workflows/release.yml`: pushing an annotated tag `vX.Y.Z` (or `vX.Y.Z-suffix` for prereleases) on `windows-2025` builds the merged `NtoLib.dll` and `Installer.exe` with the tag-derived version, packages `NtoLib_v<ver>.zip`, and publishes a GitHub Release with both attached. SemVer suffix → automatic `prerelease=true` and `make_latest=false`.
 
@@ -31,7 +33,7 @@ Before touching any tag:
    dotnet test NtoLib.sln -c Release --no-build --logger "console;verbosity=minimal"
    dotnet build NtoLib/NtoLib.csproj -c Release -p:RunILRepack=true --no-restore
    ```
-   All green before proceeding.
+   All green before proceeding. **If the smoke build or tests fail, STOP — do not create or push a tag.** A tag that crashes CI must then be rolled back (see Rollback) before retrying.
 
 ## Phase 2 — Gather changes since the last release
 
@@ -121,6 +123,8 @@ gh run watch <run-id>
 
 Expected timing on `windows-2025`: ~3 minutes (no test step in release.yml — relies on ci.yml gate).
 
+If the run fails after the tag was pushed, undo the tag and any partial release before retrying — see Rollback.
+
 ## Phase 6 — Verify the release
 
 After the workflow completes:
@@ -137,7 +141,7 @@ Check:
 
 If the release name or body needs fixing post-publish:
 ```bash
-gh release edit vX.Y.Z --title "v1.12.0"
+gh release edit vX.Y.Z --title "v1.12.0-beta1"
 gh release edit vX.Y.Z --notes "..."
 ```
 This edits the GitHub Release object (separate from the git tag annotation, which stays as-is).

--- a/.claude/skills/new-nonvisual-fb/SKILL.md
+++ b/.claude/skills/new-nonvisual-fb/SKILL.md
@@ -1,0 +1,289 @@
+---
+name: new-nonvisual-fb
+description: Use when creating a brand-new headless (non-visual) Function Block in NtoLib — "add a new headless FB", "create a StaticFBBase block", "new non-visual function block", "add an FB with no UI". Covers XML pin config, service facade, FB orchestrator class, csproj registration, build, and elevated COM registration. NOT for visual FBs that have a control (use new-visual-fb), nor for editing an existing FB.
+---
+
+# Create a New Non-Visual Function Block
+
+## When to Use
+
+Use this skill when the task involves creating a brand-new headless FB (one that extends `StaticFBBase` without visual controls, status DTOs, or renderers). Do NOT use this for visual FBs or for modifying existing FBs.
+
+## Pre-Flight
+
+Before starting, gather this information from the user (ask if not provided):
+
+1. **FB name** -- e.g. `LinkSwitcher`. Determines class name (`LinkSwitcherFB`), folder name (`LinkSwitcher/`), and XML file name (`LinkSwitcherFB.xml`).
+2. **Display name** -- the human-readable name shown in MasterSCADA's FB palette (goes into `[DisplayName(...)]`).
+3. **Category** -- which `CatIDs.CATID_*` constant to use. Default: `CatIDs.CATID_OTHER`.
+4. **Pin layout** -- list of input and output pins with names, types, and default values. Types use Russian names: `Логический`, `Строковый`, `Вещественный`, `Целый`, `Время`.
+5. **Does the FB modify the project tree?** -- if yes, use the deferred execution pattern: queue the work in runtime and post a DEFERRED action from `ToDesign()`. Do NOT mutate the tree synchronously inside `ToDesign()` while still in runtime -- it throws "modification forbidden in runtime mode". If no, execute immediately in `UpdateData()`.
+6. **Does the FB need access to `IProjectHlp`?** -- typically yes if it navigates the MasterSCADA object tree.
+
+## Step-by-Step Workflow
+
+Execute these steps in order. Track each step with the harness task tools (`TaskCreate` / `TaskUpdate`).
+
+### Step 1: Create Folder Structure
+
+```
+NtoLib/<FBName>/
+    <FBName>FB.cs              # FB orchestrator class
+    <FBName>FB.xml             # Pin configuration (EmbeddedResource)
+    Facade/
+        I<FBName>Service.cs    # Service interface
+        <FBName>Service.cs     # Service implementation
+```
+
+Add more subfolders (e.g. `Entities/`, `Logging/`) only if the service layer has enough complexity to warrant them. Do not over-engineer.
+
+### Step 2: Write the XML Pin Configuration
+
+The XML must follow this exact format:
+
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<FBConfig>
+  <Map>
+    <Items>
+      <Pin ID="1" Name="InputName" Type="Логический" DefaultValue="false"/>
+      <Pout ID="101" Name="OutputName" Type="Строковый" DefaultValue=""/>
+    </Items>
+  </Map>
+</FBConfig>
+```
+
+Rules:
+- `<Pin>` for inputs, `<Pout>` for outputs
+- `ID` attribute is uppercase (not `Id`)
+- `DefaultValue` attribute is optional but recommended
+- `Type` uses Russian type names: `Логический` (bool), `Строковый` (string), `Вещественный` (double), `Целый` (int), `Время` (DateTime)
+- Do NOT use `Direction` or `Description` attributes
+- No `<VisualMap>` section (this is a headless FB)
+- ID numbering: `ID` is a free integer with no platform-enforced ranges. By convention NtoLib starts inputs at 1 and outputs at 101 for visual separation -- this is an optional convention, not a requirement
+
+### Step 3: Write the Service Interface
+
+```csharp
+using FluentResults;
+
+namespace NtoLib.<FBName>.Facade;
+
+public interface I<FBName>Service
+{
+    // Return Result or Result<T> for operations that can fail
+    Result DoSomething(string input);
+
+    // Properties for state inspection
+    string GetLog();
+}
+```
+
+Design rules:
+- All methods that can fail return `FluentResults.Result` or `Result<T>`
+- Methods that cannot fail (e.g. `Cancel()`, property getters) may return void or direct values
+- Accept `IProjectHlp` via constructor if tree access is needed
+- Do not reference pin IDs or FB-specific types -- the service knows nothing about the FB's pin wiring
+
+### Step 4: Write the Service Implementation
+
+The service contains ALL business logic. The FB class must never contain business logic.
+
+- Receive dependencies via constructor injection (`IProjectHlp`, configuration values)
+- Use `Result.Ok()` and `Result.Fail("message")` for all fallible operations
+- If the FB modifies the tree, expose `HasPendingTask`, `PendingPlan`, and a `FlushPending()` or `Execute(plan)` method
+
+### Step 5: Write the FB Class
+
+Use this template. Adapt based on whether the FB modifies the tree or not.
+
+```csharp
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+using FB;
+
+using InSAT.Library.Interop;
+
+using NtoLib.<FBName>.Facade;
+
+namespace NtoLib.<FBName>;
+
+[Serializable]
+[ComVisible(true)]
+[Guid("GENERATE-A-NEW-GUID")]
+[CatID(CatIDs.CATID_OTHER)]
+[DisplayName("<Display Name>")]
+public class <FBName>FB : StaticFBBase
+{
+    // Pin ID constants -- must match XML exactly
+    private const int TriggerPinId = 1;
+    private const int SuccessPinId = 101;
+    private const int ErrorMessagePinId = 102;
+
+    [NonSerialized] private I<FBName>Service? _service;
+    [NonSerialized] private bool _previousTrigger;
+    [NonSerialized] private bool _isRuntimeInitialized;
+
+    protected override void ToRuntime()
+    {
+        base.ToRuntime();
+        InitializeRuntime();
+    }
+
+    protected override void ToDesign()
+    {
+        // If tree-modifying: POST a deferred flush here (do not mutate the tree
+        // synchronously -- it throws "modification forbidden in runtime mode").
+        base.ToDesign();
+        CleanupRuntime();
+    }
+
+    protected override void UpdateData()
+    {
+        base.UpdateData();
+
+        if (!_isRuntimeInitialized)
+        {
+            return;
+        }
+
+        ProcessCommand();
+    }
+
+    private void InitializeRuntime()
+    {
+        if (_isRuntimeInitialized)
+        {
+            return;
+        }
+
+        try
+        {
+            // If tree access needed:
+            if (TreeItemHlp?.Project == null)
+            {
+                throw new InvalidOperationException("TreeItemHlp.Project is null.");
+            }
+
+            _service = new <FBName>Service(TreeItemHlp.Project);
+            _previousTrigger = false;
+            _isRuntimeInitialized = true;
+        }
+        catch (Exception exception)
+        {
+            _isRuntimeInitialized = false;
+            WriteOutputs(false, $"Initialization failed: {exception.Message}");
+        }
+    }
+
+    private void CleanupRuntime()
+    {
+        _isRuntimeInitialized = false;
+        _service = null;
+    }
+
+    private void ProcessCommand()
+    {
+        var currentTrigger = GetPinValue<bool>(TriggerPinId);
+        var isRisingEdge = currentTrigger && !_previousTrigger;
+        _previousTrigger = currentTrigger;
+
+        if (!isRisingEdge || _service == null)
+        {
+            return;
+        }
+
+        var result = _service.DoSomething("input");
+        WriteOutputs(result.IsSuccess, result.IsFailed ? string.Join("; ", result.Errors) : string.Empty);
+    }
+
+    private void WriteOutputs(bool success, string errorMessage)
+    {
+        var now = DateTime.UtcNow;
+
+        SetPinValue(SuccessPinId, success, now);
+        SetPinValue(ErrorMessagePinId, errorMessage, now);
+    }
+}
+```
+
+Critical rules for the FB class:
+- `sealed` is optional -- most NtoLib FBs are not sealed; add it only to forbid subclassing
+- `[Serializable]` is required
+- `[ComVisible(true)]` is required
+- Generate a unique GUID for each new FB (use `Guid.NewGuid()` or an online generator)
+- All non-serializable fields must be marked `[NonSerialized]`
+- `_previousTrigger` must be reset to `false` in `InitializeRuntime()` so the first `true` after runtime start is detected
+- Rising-edge pattern: `var isRisingEdge = currentTrigger && !_previousTrigger;`
+- `WriteOutputs` helper centralizes all pin writes with a shared `DateTime.UtcNow` timestamp
+- For tree-modifying FBs, call flush BEFORE `base.ToDesign()`
+
+### Step 6: Update csproj
+
+NtoLib uses explicit `<Compile Include>` entries. Add entries for every new `.cs` file and an `<EmbeddedResource>` entry for the XML.
+
+```xml
+<!-- In NtoLib.csproj, within an appropriate <ItemGroup> -->
+<Compile Include="<FBName>\<FBName>FB.cs" />
+<Compile Include="<FBName>\Facade\I<FBName>Service.cs" />
+<Compile Include="<FBName>\Facade\<FBName>Service.cs" />
+<EmbeddedResource Include="<FBName>\<FBName>FB.xml" />
+```
+
+Find the existing `<Compile Include>` entries for similar FBs (e.g. `LinkSwitcher\`) and add the new entries nearby for consistency.
+
+### Step 7: Build and Verify
+
+Run `dotnet build NtoLib.sln --no-incremental` from the repo root. The build must produce:
+- **Zero new errors** (pre-existing warnings are acceptable)
+- **Zero new warnings from the new FB code**
+
+If the build fails, fix the issues before proceeding. Common causes:
+- Missing `<Compile Include>` entry in csproj
+- Pin ID mismatch between XML and code constants
+- Missing `using` directives
+
+### Step 8: Verify XML-Code Alignment
+
+After the build passes, manually verify:
+- Every `const int *PinId` in the FB class has a matching `<Pin>` or `<Pout>` entry in the XML with the same `ID` value
+- No XML pin exists without a corresponding constant in code (dead pins cause confusion)
+- Input pins use `GetPinValue<T>()`, output pins use `SetPinValue()`
+
+### Step 9: Deploy and Register (local MasterSCADA testing)
+
+A green build is NOT enough to see the FB in MasterSCADA. The DLL must be deployed AND
+COM-registered, and registration **must run elevated**.
+
+1. Deploy: `Build/Deploy.ps1` (build -> ILRepack merge -> copy `NtoLib.dll` to the install dir).
+   **`Deploy.ps1` only copies -- it does NOT register COM.**
+2. Register from an **Administrator** prompt in the MasterSCADA install dir:
+   ```
+   netreg.exe NtoLib.dll /showerror      (or: NtoLib_reg.bat, "Run as administrator")
+   ```
+   `netreg` writes `netreg.log` in its own (Program Files) directory at startup and aborts
+   with `UnauthorizedAccessException` if not elevated -- registering nothing, often with no
+   visible error. The HKLM COM keys also require elevation.
+3. **Restart MasterSCADA** -- it caches library metadata and will not pick up new/updated
+   types until restarted.
+
+A **new GUID** (every new FB) or a **renamed type/namespace** requires re-running `netreg`
+elevated; routine edits to an already-registered type do not. Skipping this is the #1 cause
+of "the FB silently won't appear / won't instantiate, no exception, no logs" (the failure is
+at COM `CoCreateInstance`, before any managed code runs).
+
+## Common Pitfalls
+
+- **netreg run non-elevated**: aborts on the `netreg.log` write to Program Files, registers
+  nothing, FB never appears / silently fails to instantiate. Always run `NtoLib_reg.bat` as
+  Administrator, then restart MasterSCADA.
+- **Changing a `[Guid]` after first release** (or renaming the type's full name): existing
+  projects can no longer create saved instances, and the new identity needs re-registration.
+- **XML marked as `<Content>` instead of `<EmbeddedResource>`**: compiles fine but fails at runtime with missing resource errors.
+- **`Id` instead of `ID` in XML**: silently ignored, pins will not be created.
+- **Forgetting `[NonSerialized]` on service field**: causes serialization exceptions when MasterSCADA saves the project.
+- **Calling `Connect()`/`Disconnect()` during runtime**: throws "modification forbidden in runtime mode" exception. Use deferred execution pattern.
+- **Not resetting `_previousTrigger` in `InitializeRuntime()`**: first trigger after runtime start may be missed or falsely detected.
+- **Redeclaring `[ComRegisterFunction]`/`[ComUnregisterFunction]`**: unnecessary -- `StaticFBBase` already provides them via inheritance, and no shipping NtoLib FB redeclares them. An FB missing from the palette is almost always an un-elevated or forgotten `netreg`, not these methods.

--- a/.claude/skills/new-visual-fb/SKILL.md
+++ b/.claude/skills/new-visual-fb/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: new-visual-fb
+description: Use when creating a brand-new visual Function Block in NtoLib — "add a new visual FB", "create a VisualFBBase block with a control", "new FB with a mnemoscheme control", "make an editor-style copy of an FB". Covers the XML Map/VisualMap, FB + VisualControlBase control with distinct GUIDs, palette bmp, DI composition, csproj registration, build, elevated COM registration, and the shared-core / thin-shell copy pattern. NOT for headless FBs with no control (use new-nonvisual-fb), nor for editing an existing FB in place.
+---
+
+# Create a New Visual Function Block
+
+Build a new visual FB end to end: the `VisualFBBase` orchestrator, its `VisualControlBase` WinForms control, the `<Map>`/`<VisualMap>` XML, the palette icon, DI wiring, and the elevated COM registration that makes it droppable.
+
+## When to Use
+
+Use this skill when creating a brand-new visual FB: a class extending `VisualFBBase` (or
+`VisualFBBaseExtended`) paired with a `VisualControlBase` WinForms control shown on a
+MasterSCADA mnemoscheme. Also use it when the task is to **copy/derive** an existing visual
+FB with a feature stripped or changed (see "Shared-Core / Thin-Shell" below) -- do NOT
+duplicate the whole module tree.
+
+**Base class:** use `VisualFBBase` for a control that builds a DI service graph in
+`InitializeRuntime` (the templates below model this -- the MbeTable family). Use
+`VisualFBBaseExtended` for simpler device-style FBs driven through `SetVisualAndUiPin` /
+`GetVisualPin` / `EventTrigger` without DI (ValveFB/PumpFB). The templates below show the
+`VisualFBBase` + DI variant; for the extended variant, model an existing
+`VisualFBBaseExtended` FB instead.
+
+For headless FBs (`StaticFBBase`, no control), use `new-nonvisual-fb` instead.
+
+## Pre-Flight
+
+Ask the user if not provided:
+
+1. **FB name** -- e.g. `MbeTable`. Determines FB class (`MbeTableFB`), control class, folder,
+   namespace, and the embedded XML/bmp names.
+2. **Display name** -- palette name, goes in `[DisplayName(...)]` on BOTH the FB and the control.
+3. **Category** -- `CatIDs.CATID_*`. Default `CatIDs.CATID_OTHER`.
+4. **Pin layout** -- two groups: `<Map>` (logic pins) and `<VisualMap>` (design-time visual
+   properties echoed to pins). Russian type names include `Логический`, `Строковый`,
+   `Вещественный`, `Целый`, `БеззнаковыйЦелый`, `БеззнаковыйКороткийЦелый`, `Время` --
+   match the exact spelling used in an existing working XML for the type you need.
+5. **Does it need services / DI?** -- a non-trivial control uses a DI graph built in
+   `InitializeRuntime`. A trivial control may not.
+6. **Two fresh GUIDs** -- generate one for the FB class and a DISTINCT one for the control
+   class; never reuse an existing type's GUID. Generate both with PowerShell:
+   ```powershell
+   [guid]::NewGuid(); [guid]::NewGuid()
+   ```
+
+## The FB <-> XML <-> resource naming rule (read first -- it is the #1 silent failure)
+
+MasterSCADA locates an FB's embedded XML by **type full name**: the type
+`NtoLib.Recipes.MbeTable.MbeTableFB` binds to the embedded resource
+`NtoLib.Recipes.MbeTable.MbeTableFB.xml`. With `<RootNamespace>NtoLib</RootNamespace>`, an
+`<EmbeddedResource Include="Recipes\MbeTable\MbeTableFB.xml"/>` gets exactly that manifest
+name only because the folder path matches the namespace.
+
+Therefore: **folder == namespace == the FB class's containing namespace.** If you move or
+rename the folder/namespace, the XML/bmp resource names move with it (good), but every
+existing COM registration that mapped the CLSID to the OLD type full name becomes stale --
+re-register (see "Deploy and Register"). Verify the manifest name in the built DLL with
+`grep -a -o "NtoLib\.[A-Za-z.]*<FBName>\.xml" NtoLib/bin/Debug/NtoLib.dll`.
+
+## Step-by-Step Workflow
+
+Track steps with the harness task tools (`TaskCreate` / `TaskUpdate`).
+
+### Step 1: Folder Structure
+
+```
+NtoLib/<Area>/<FBName>/            # folder path MUST mirror the namespace
+    <FBName>FB.cs                  # FB orchestrator (VisualFBBase)
+    <FBName>FB.xml                 # EmbeddedResource, name == FB type full name
+    <FBName>FB.bmp                 # EmbeddedResource palette icon, name == FB type full name
+    <Control>.cs                   # control (VisualControlBase) + attributes
+    <Control>.Designer.cs          # InitializeComponent (layout)
+    <Control>.resx                 # EmbeddedResource, DependentUpon the control .cs
+    <Control>.Lifecycle.cs / .Buttons.cs / ...  # optional partials
+```
+
+Keep the COM-bound shell thin; put domain/service logic in separate, COM-neutral classes
+(reused, not duplicated -- see shared-core pattern).
+
+### Step 2: XML -- `<Map>` and `<VisualMap>`
+
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<FBConfig>
+  <Map>
+    <Items>
+      <Pin  ID="1"   Name="SomeInput"  Type="Логический" DefaultValue="false"/>
+      <Pout ID="101" Name="SomeOutput" Type="Вещественный"/>
+    </Items>
+  </Map>
+  <VisualMap>
+    <!-- design-time visual properties echoed to pins -->
+    <Items>
+      <Pout ID="1003" Name="SomeAddr" Type="БеззнаковыйЦелый"/>
+    </Items>
+  </VisualMap>
+</FBConfig>
+```
+
+Rules: `<Pin>` inputs, `<Pout>` outputs; uppercase `ID`. `ID` is a free integer with no
+platform-enforced ranges -- real NtoLib FBs use IDs like 5, 10, 50, 100, 1000. Any consistent
+numbering works; a common (optional) convention keeps logic pins low and `<VisualMap>` pins in
+a high band (~1000+). Empty `<Items></Items>` is valid if pins are added dynamically in code
+(as the editor FB does), but the file must still exist and bind by name.
+
+### Step 3: FB Class (`VisualFBBase`)
+
+```csharp
+[CatID(CatIDs.CATID_OTHER)]
+[Guid("FRESH-GUID-FOR-THE-FB")]
+[FBOptions(FBOptions.EnableChangeConfigInRT)]
+[VisualControls(typeof(<Control>))]
+[DisplayName("<Display Name>")]
+[ComVisible(true)]
+[Serializable]
+public partial class <FBName>FB : VisualFBBase
+{
+    [NonSerialized] private IServiceProvider? _serviceProvider;
+
+    protected override void ToDesign()  { base.ToDesign();  CleanupRuntime(); }
+    protected override void ToRuntime() { base.ToRuntime(); InitializeRuntime(); }
+    public override void Dispose()      { CleanupRuntime(); base.Dispose(); }
+
+    private void InitializeRuntime()
+    {
+        if (_serviceProvider != null) return;
+        // build config + DI graph here; surface failures (MessageBox + rethrow) so they
+        // are visible at runtime. Design-time (drag-drop) must NOT throw.
+    }
+
+    private void CleanupRuntime() { /* dispose provider, null it */ }
+}
+```
+
+Rules:
+- `[VisualControls(typeof(<Control>))]` registers the default control. The attribute also has
+  a params overload `[VisualControls(typeof(Default), typeof(Other), ...)]` that registers
+  several controls; MasterSCADA then shows a right-click chooser at drop time. One default
+  control is the common case.
+- Fresh, unique `[Guid]`. `[ComVisible(true)]`, `[Serializable]`, public parameterless ctor
+  (implicit is fine) -- COM activation requires it.
+- All caches/services/providers `[NonSerialized]`.
+- `ToDesign`/drag-drop path must not throw (the host swallows design-time exceptions -> the
+  control silently fails to add). Do heavy work in `ToRuntime`/`InitializeRuntime`.
+- Logging only bootstraps at runtime; do not expect design-time logs.
+
+### Step 4: Control Class (`VisualControlBase`)
+
+```csharp
+[ComVisible(true)]
+[DisplayName("<Display Name>")]
+[Guid("FRESH-GUID-FOR-THE-CONTROL")]   // MUST differ from the FB's GUID
+public partial class <Control> : VisualControlBase
+{
+    public <Control>() : base(true)
+    {
+        InitializeComponent();
+    }
+}
+```
+
+- Distinct fresh `[Guid]`, `[ComVisible(true)]`, public parameterless ctor.
+- `InitializeComponent()` lives in `.Designer.cs`. If it references the control's own `.resx`
+  via `new ComponentResourceManager(typeof(<Control>))`, the resx manifest name must equal
+  the control's type full name (it does automatically when folder == namespace and the resx
+  is `DependentUpon` the control `.cs`). Shared images via `global::NtoLib.Properties.Resources.*`
+  do not depend on the control's resx.
+- `VisualControlBase` exposes `FBConnector`; read `FBConnector.Fb` and bail out cleanly when
+  it is not your FB type (design-time guard) -- do not throw.
+
+### Step 5: Palette bmp
+
+Add `<FBName>FB.bmp` next to the FB. EmbeddedResource; its manifest name must equal the FB
+type full name + `.bmp`. A standard small palette icon; copy an existing FB's bmp as a
+starting point if unsure.
+
+### Step 6: csproj (globs are disabled -- add everything explicitly)
+
+```xml
+<Compile Include="<Area>\<FBName>\<FBName>FB.cs" />
+<!-- all FB + control partials ... -->
+<Compile Include="<Area>\<FBName>\<Control>.Designer.cs">
+  <DependentUpon><Control>.cs</DependentUpon>
+</Compile>
+<EmbeddedResource Include="<Area>\<FBName>\<FBName>FB.bmp" />
+<EmbeddedResource Include="<Area>\<FBName>\<FBName>FB.xml" />
+<EmbeddedResource Include="<Area>\<FBName>\<Control>.resx">
+  <DependentUpon><Control>.cs</DependentUpon>
+</EmbeddedResource>
+```
+
+### Step 7: Build
+
+- Un-merged (for tests): `dotnet build NtoLib.sln`
+- Merged (deployable): `dotnet build NtoLib/NtoLib.csproj -p:RunILRepack=true`
+- Confirm the embedded resource names in the DLL match the type full names (grep, see naming
+  rule above). Run `dotnet format NtoLib.sln`.
+
+### Step 8: Deploy and Register (REQUIRED to see/drop the control in MasterSCADA)
+
+A green build is not enough. The control instantiates via COM `CoCreateInstance`; if the
+CLSID is unregistered, it **silently fails to drop -- no exception, no logs**.
+
+1. Deploy with `Build/Deploy.ps1` (build -> merge -> copy). **It does NOT register COM.**
+2. From an **Administrator** prompt in the MasterSCADA install dir:
+   `netreg.exe NtoLib.dll /showerror`  (or `NtoLib_reg.bat`, Run as administrator).
+   netreg aborts non-elevated (cannot write `netreg.log` in Program Files) and registers
+   nothing. HKLM COM keys also need elevation. Registering both the FB and control CLSIDs
+   requires this elevated run.
+3. **Restart MasterSCADA** (it caches library metadata).
+
+Verify (optional):
+`reg query "HKLM\SOFTWARE\WOW6432Node\Classes\CLSID\{<control-guid>}\InprocServer32"` ->
+`Class` should equal the control's type full name.
+
+## Shared-Core / Thin-Shell (copying an existing FB)
+
+When asked for a "copy" of an FB with a feature stripped (e.g. a PLC-less editor), do NOT
+duplicate the module. Create a new thin shell (FB + control + XML + bmp) with **fresh GUIDs**
+and reuse the COM-neutral core verbatim:
+
+- Never share a base class between two COM-visible FB/control types (it risks COM identity /
+  serialization). Reuse via **static helpers and composition** (e.g.
+  `RecipeFbConfigurationHelper`) -- pass platform bits (pin read via `OpcQuality`, tree
+  mutation) in as delegates so the helper stays unit-testable from `Tests`.
+- Fork the DI graph through one configurator with a shared `RegisterShared` and per-variant
+  deltas (omit PLC services, substitute no-op/slim providers behind interfaces).
+- The WinForms control shell is the one piece intentionally duplicated (COM-bound glue).
+
+## Common Pitfalls
+
+- **netreg run non-elevated** -> aborts on `netreg.log` write -> nothing registered -> control
+  silently fails to drop, no exception, no logs. Run `NtoLib_reg.bat` as Administrator, then
+  restart MasterSCADA. This is the dominant cause of "fails to add, no error."
+- **Renaming the folder/namespace** of an existing FB changes its type full name -> the old
+  CLSID registration is stale and `CoCreateInstance` silently fails until you re-register
+  elevated. (The embedded XML/bmp names follow the namespace and stay correct automatically.)
+- **FB and control sharing one GUID, or reusing an existing FB's GUID** -> CLSID collision;
+  only one registers.
+- **Throwing at design time** (FB ctor / `ToDesign` / control `InitializeComponent`) -> the
+  host swallows it and the drop silently fails. Defer heavy work to `ToRuntime`.
+- **XML/bmp/resx as `<Content>` instead of `<EmbeddedResource>`, or a folder that does not
+  match the namespace** -> resource name will not match the type full name; the FB will not
+  bind its config.
+- **Changing a `[Guid]` or a public FB property name/type after release** -> existing projects
+  can no longer load their saved instances (the COM identity / serialization contract changed).
+- **Expecting design-time logs** -> logging only starts at `ToRuntime`. A design-time failure
+  produces no logs by design.
+
+## Key Rules (the load-bearing invariants)
+
+- FB and control each carry a **distinct, fresh** `[Guid]`; never reuse one.
+- **folder == namespace**, so the embedded XML/bmp manifest name equals the type full name.
+- XML/bmp/resx are `<EmbeddedResource>` (never `<Content>`); every new `.cs` is an explicit
+  `<Compile Include>` (globs are disabled).
+- **Never throw at design time** (ctor / `ToDesign` / `InitializeComponent`) -- defer heavy
+  work to `ToRuntime`.
+- **Never share a base class** across two COM-visible FB/control types; reuse via static
+  helpers / composition.
+- After deploy, run **`netreg` elevated + restart MasterSCADA** whenever a type is added,
+  renamed, or its GUID changes.

--- a/.claude/skills/write-fb-docs/SKILL.md
+++ b/.claude/skills/write-fb-docs/SKILL.md
@@ -1,0 +1,244 @@
+---
+name: write-fb-docs
+description: "Step-by-step workflow for writing documentation for a Function Block in NtoLib. Covers both headless and visual FBs. Produces a Russian-language markdown doc following the established pattern in Docs/."
+---
+
+# Write Documentation for a Function Block
+
+## When to Use
+
+Use this skill when the task involves creating or substantially rewriting documentation for an existing Function Block in `Docs/`. Do NOT use for code changes, known issues, or MbeTable sub-module docs.
+
+## Governing Principle: External Contract Only
+
+The doc describes what the FB does from the outside -- its pins, properties, observable behavior, and user-facing messages. It does NOT describe how the FB is implemented internally.
+
+**Include:** pins, types, defaults, visual properties, user-visible behavior (what happens when the user does X), error messages the user will see, constraints the user must respect (e.g. "wait 20 seconds after stopping Runtime before editing the tree").
+
+**Exclude:** class names, design patterns, internal timers, polling intervals, field names, debounce constants, arbitration logic, serialization details, threading model, control update mechanisms. None of these affect how the user interacts with the FB.
+
+**Threshold for inclusion:** a detail belongs in the doc only if the user must know it to use the FB correctly or to understand behavior they can act on. If a detail is purely internal and the user cannot observe or react to it, omit it.
+
+**When unsure** whether a detail is significant enough to include, ask the user before writing it in. Do not guess -- err on the side of omission.
+
+## Pre-Flight
+
+Before starting, gather this information (read from source code if not provided by the user):
+
+1. **FB type** -- headless (`StaticFBBase`) or visual (`VisualFBBase` / `VisualFBBaseExtended`).
+2. **FB class file** -- e.g. `NtoLib/NumericBox/NumericBoxFB.cs`.
+3. **XML file** -- e.g. `NtoLib/NumericBox/NumericBoxFB.xml`.
+4. **Control file** (visual FBs only) -- e.g. `NtoLib/NumericBox/NumericBoxControl.cs`.
+5. **Service/facade files** (headless FBs) -- e.g. `NtoLib/LinkSwitcher/Facade/`.
+
+Read all relevant source files before writing to ensure accuracy -- but remember, the source is for your understanding only. The doc output must contain none of the internal details you read.
+
+## Reference Implementations
+
+Read at least one existing doc of the same FB type before writing:
+
+- **Headless FB docs:** `Docs/config-loader.md`, `Docs/link-switcher.md`
+- **Visual FB doc:** `Docs/numeric-box.md`
+- **Complex headless FB doc:** `Docs/trend-pens-manager.md`
+
+Mimic their *structure*, not every word: `numeric-box.md`'s TL;DR says "работает через debounce…" and the `readme.md` TOC mentions "арбитрация" — both leak an internal-mechanism term that rule #1 forbids. Do not copy those phrasings; describe observable behavior instead.
+
+## Language and Style Rules
+
+1. **External contract only.** Describe what the FB does, not how it is built. No class names, no pattern names, no internal constants, no architecture. See "Governing Principle" above.
+2. **All text in Russian.** Section headers, table content, TL;DR, prose -- everything.
+3. **Identifiers keep their original form, never translated:** pin names, enum values, and property names stay in English (`Input`, `Output`, `DisplayFormat`). For the `Тип` column, follow the same-type reference doc: headless FB docs use lowercase English type names (`bool`, `string`, `double`); the visual `numeric-box.md` uses the Russian XML type names (`Вещественный`). Match the existing same-type docs rather than mixing the two.
+4. **Prefer name-only pin tables (no DispId/ID column).** Pin IDs are an internal addressing detail; users identify pins by name (this matches `numeric-box.md`). Note: the older headless docs (`config-loader.md`, `link-switcher.md`, `trend-pens-manager.md`) include a leading `| ID |` column — when *rewriting* one of those, keep its existing column shape unless the user asks to modernize it, to avoid a gratuitous reformat.
+5. **Concise prose.** Short paragraphs, no filler. Each sentence adds information.
+6. **Tables over paragraphs** when listing structured data (pins, properties, errors).
+7. **No code blocks** unless showing a tree structure, YAML config, or format example.
+8. **File name:** `Docs/<fb-name-lowercase-kebab>.md` (e.g. `numeric-box.md`, `config-loader.md`).
+
+## Document Structure
+
+### Common Sections (both headless and visual)
+
+```markdown
+# <EnglishName> -- <Русское описание>
+
+> **TL;DR:** <2-3 предложения: что делает, как работает, ключевые особенности.>
+
+## 1. Интерфейс
+
+### Входы
+
+| Имя | Тип | Описание |
+|-----|-----|----------|
+
+### Выходы
+
+| Имя | Тип | Описание |
+|-----|-----|----------|
+
+### События (Warnings)              ← only if the FB has events
+
+| Имя | Условие |
+|-----|---------|
+
+## N. Логика работы                  ← observable input-output behavior, not internal algorithm
+
+## N. Валидация при вводе            ← what the user sees when input is rejected
+
+## N. Обработка ошибок               ← user-visible error categories and consequences
+```
+
+### Additional Sections for Visual FBs
+
+Insert after section 1 (Интерфейс):
+
+```markdown
+## 2. Визуальные свойства (окно настроек)
+
+| Свойство | По умолчанию | Описание |
+|----------|--------------|----------|
+```
+
+If the control has enums exposed as properties (e.g. `DisplayFormat`, `FontSizeMode`), list their values:
+
+```markdown
+### <EnumName> (<EnumDisplayName>)
+
+- `Value1` -- описание
+- `Value2` -- описание
+```
+
+### Additional Sections for Headless FBs
+
+Add if applicable:
+
+```markdown
+## N. Параметры (окно настроек)
+
+| Свойство | По умолчанию | Описание |
+|----------|--------------|----------|
+
+## N. Логирование                    ← if the FB writes to a log file
+
+- **Путь:** ...
+- **Ротация:** ...
+- **Содержимое:** ...
+
+## N. Режим исполнения               ← if the FB uses deferred execution
+```
+
+### Section Numbering
+
+Number sections sequentially starting from 1. The exact numbers depend on which sections are included. Do not skip numbers.
+
+## Condensed Template: Visual FB
+
+```markdown
+# <Name> -- <Русское название>
+
+> **TL;DR:** <Краткое описание.>
+
+## 1. Интерфейс
+
+### Входы
+
+| Имя | Тип | Описание |
+|-----|-----|----------|
+| <PinName> | <Тип> | <Описание> |
+
+### Группа <GroupName>               ← only if XML has <Group> elements
+
+| Имя | Тип | Описание |
+|-----|-----|----------|
+
+<Пояснение к группе, если необходимо.>
+
+### Выходы
+
+| Имя | Тип | Описание |
+|-----|-----|----------|
+
+### События (Warnings)
+
+| Имя | Условие |
+|-----|---------|
+
+<Примечания к событиям.>
+
+## 2. Визуальные свойства (окно настроек)
+
+| Свойство | По умолчанию | Описание |
+|----------|--------------|----------|
+
+### <EnumDisplayName> (<EnumTypeName>)
+
+- `Value` -- описание
+
+## 3. Логика работы
+
+<Что происходит при переходе в Runtime, при вводе значения, при получении внешнего сигнала. Описывать наблюдаемое поведение, а не внутренний алгоритм.>
+
+## 4. Валидация при вводе
+
+<Что видит пользователь при вводе некорректных данных. Какие значения отклоняются и почему.>
+```
+
+## Condensed Template: Headless FB
+
+```markdown
+# <Name> -- <Русское название>
+
+> **TL;DR:** <Краткое описание.>
+
+## 1. Интерфейс
+
+### Входы
+
+| Имя | Тип | Описание |
+|-----|-----|----------|
+
+### Выходы
+
+| Имя | Тип | Описание |
+|-----|-----|----------|
+
+### Параметры (окно настроек)
+
+| Свойство | По умолчанию | Описание |
+|----------|--------------|----------|
+
+## 2. Логика работы
+
+<Что делает ФБ при старте, по команде, при получении данных. Фазы, последовательность действий -- с точки зрения пользователя.>
+
+## 3. Обработка ошибок
+
+### Критические ошибки (прерывают операцию)
+
+| Ситуация | Поведение |
+|----------|-----------|
+
+### Предупреждения (не прерывают операцию)
+
+| Ситуация | Поведение |
+|----------|-----------|
+
+## 4. Логирование
+
+- **Путь:** ...
+- **Ротация:** ...
+```
+
+## After Writing
+
+1. **Update `Docs/readme.md`**: add a row to the 3-column table of contents — `| № | [<Name>](<file>.md) | <короткое описание> |` — using the next sequential `№`. Keep the description free of internal-mechanism terms (rule #1).
+2. **Review**: re-read the doc against the source code. Verify every pin name, type, property name, default value, and event name matches the current code exactly.
+3. **Do NOT commit** unless the user explicitly asks.
+
+## Common Pitfalls
+
+- **Leaking implementation details**: this is the most common mistake. The doc reader is an operator or integrator, not a developer. Do not mention: class names (`ValueArbiter`, `EventTrigger`), design patterns (debounce, polling, arbitration), internal constants (precision thresholds, timer intervals), field names, threading details, or how the control updates itself. Describe only what the user observes. If you catch yourself writing "internally" or "under the hood" -- delete that paragraph.
+- **Including IDs**: pin IDs are implementation details. Do not add ID columns to tables.
+- **Inventing behavior not in the code**: every statement in the doc must be traceable to a specific code path. If unsure, read the source.
+- **Overly long TL;DR**: keep to 2-3 sentences. The TL;DR is a summary, not an introduction.
+- **Borderline details -- guessing instead of asking**: if you are unsure whether a detail is user-actionable (e.g. "events are suppressed for 5 seconds after Runtime start"), ask the user instead of including it by default. Err on the side of omission.
+- **Missing sections**: if the FB has events, document them. If it has visual properties, document them. Do not skip sections that apply.


### PR DESCRIPTION
FB-authoring skills, split out of the MbeTableEditor PR (#103) so that PR stays scoped to the feature.

- **new-visual-fb** (new): create a visual FB — FB + `VisualControlBase` control, `<Map>`/`<VisualMap>` XML, distinct GUIDs, DI wiring, elevated COM registration, and the shared-core copy pattern.
- **new-nonvisual-fb**: add the deploy + elevated-`netreg` step; drop the incorrect "`[ComRegisterFunction]`/`[ComUnregisterFunction]` required" and "must be `sealed`" claims (verified against `StaticFBBase` + the shipping FBs); reframe pin-ID numbering as an optional convention.
- **write-fb-docs**: reconcile the type-name and ID-column rules with the actual `Docs/` corpus.
- **make-release**: fix frontmatter `name` (`release` → `make-release`) and add a NOT-clause.

No code changes.
