### PR TITLE
refactor: unify internal domain-entity naming, codify conventions in FB skills

### DIFF
--- a/.claude/skills/new-nonvisual-fb/SKILL.md
+++ b/.claude/skills/new-nonvisual-fb/SKILL.md
@@ -20,6 +20,24 @@ Before starting, gather this information from the user (ask if not provided):
 5. **Does the FB modify the project tree?** -- if yes, use the deferred execution pattern: queue the work in runtime and post a DEFERRED action from `ToDesign()`. Do NOT mutate the tree synchronously inside `ToDesign()` while still in runtime -- it throws "modification forbidden in runtime mode". If no, execute immediately in `UpdateData()`.
 6. **Does the FB need access to `IProjectHlp`?** -- typically yes if it navigates the MasterSCADA object tree.
 
+## Naming conventions for domain entities
+
+- Device-group entities use the canonical English plural terms: `Shutters`, `Sources`,
+  `ChamberHeaters`, `Waters`, `Gases`, `VacuumMeters`, `Pyrometers`, `Interferometers`,
+  `Turbines`, `Cryos`, `Ions`. New pins, YAML sections, DTOs, and UI labels for a device
+  group reuse the canonical term — do not invent synonyms (one concept = one identifier
+  across the whole vertical slice; `Waters` and `WaterChannels` must never coexist).
+- Compound adjuncts stay singular (`shutterNames`, `_pyrometerNames`) — standard English,
+  matching the existing `ShutterNames`/`HeaterNames` YAML group keys.
+- An enum describing the type of a single device is singular (`PumpType.Turbine`,
+  `PumpType.Ion`) — plural applies to groups, not to one device's kind.
+- An identifier that carries a frozen contract string (legacy YAML key, pin name,
+  customer tree node name) follows the contract string exactly, even when it violates the
+  conventions above — greppability against customer configs beats style.
+- Design-time properties of a `[Serializable]` FB are a serialization contract: their
+  backing fields persist in customer project files. Never rename them after release; a
+  DTO that mirrors them keeps their names.
+
 ## Step-by-Step Workflow
 
 Execute these steps in order. Track each step with the harness task tools (`TaskCreate` / `TaskUpdate`).

--- a/.claude/skills/new-visual-fb/SKILL.md
+++ b/.claude/skills/new-visual-fb/SKILL.md
@@ -58,6 +58,24 @@ existing COM registration that mapped the CLSID to the OLD type full name become
 re-register (see "Deploy and Register"). Verify the manifest name in the built DLL with
 `grep -a -o "NtoLib\.[A-Za-z.]*<FBName>\.xml" NtoLib/bin/Debug/NtoLib.dll`.
 
+## Naming conventions for domain entities
+
+- Device-group entities use the canonical English plural terms: `Shutters`, `Sources`,
+  `ChamberHeaters`, `Waters`, `Gases`, `VacuumMeters`, `Pyrometers`, `Interferometers`,
+  `Turbines`, `Cryos`, `Ions`. New pins, YAML sections, DTOs, and UI labels for a device
+  group reuse the canonical term — do not invent synonyms (one concept = one identifier
+  across the whole vertical slice; `Waters` and `WaterChannels` must never coexist).
+- Compound adjuncts stay singular (`shutterNames`, `_pyrometerNames`) — standard English,
+  matching the existing `ShutterNames`/`HeaterNames` YAML group keys.
+- An enum describing the type of a single device is singular (`PumpType.Turbine`,
+  `PumpType.Ion`) — plural applies to groups, not to one device's kind.
+- An identifier that carries a frozen contract string (legacy YAML key, pin name,
+  customer tree node name) follows the contract string exactly, even when it violates the
+  conventions above — greppability against customer configs beats style.
+- Design-time properties of a `[Serializable]` FB are a serialization contract: their
+  backing fields persist in customer project files. Never rename them after release; a
+  DTO that mirrors them keeps their names.
+
 ## Step-by-Step Workflow
 
 Track steps with the harness task tools (`TaskCreate` / `TaskUpdate`).

--- a/NtoLib/ConfigLoader/Entities/ConfigLoaderGroups.cs
+++ b/NtoLib/ConfigLoader/Entities/ConfigLoaderGroups.cs
@@ -12,7 +12,7 @@ public sealed record ConfigLoaderGroups(
 	ConfigLoaderGroup Sources,
 	ConfigLoaderGroup ChamberHeaters,
 	ConfigLoaderGroup Gases,
-	ConfigLoaderGroup Water)
+	ConfigLoaderGroup Waters)
 {
 	public static ConfigLoaderGroups Default { get; } = new(
 		new ConfigLoaderGroup("Shutters", "Shutters", 16, 1000, 2000),

--- a/NtoLib/ConfigLoader/Entities/LoaderDto.cs
+++ b/NtoLib/ConfigLoader/Entities/LoaderDto.cs
@@ -4,6 +4,6 @@ public sealed record LoaderDto(
 	string[] Shutters,
 	string[] Sources,
 	string[] ChamberHeaters,
-	string[] WaterChannels,
+	string[] Waters,
 	string[] Gases
 );

--- a/NtoLib/ConfigLoader/Entities/YamlConfigDto.cs
+++ b/NtoLib/ConfigLoader/Entities/YamlConfigDto.cs
@@ -14,16 +14,16 @@ public sealed class YamlConfigDto
 	}
 
 	public YamlConfigDto(
-		Dictionary<string, string> shutter,
+		Dictionary<string, string> shutters,
 		Dictionary<string, string> sources,
-		Dictionary<string, string> chamberHeater,
-		Dictionary<string, string> water,
+		Dictionary<string, string> chamberHeaters,
+		Dictionary<string, string> waters,
 		Dictionary<string, string> gases)
 	{
-		Shutters = shutter;
+		Shutters = shutters;
 		Sources = sources;
-		ChamberHeaters = chamberHeater;
-		Waters = water;
+		ChamberHeaters = chamberHeaters;
+		Waters = waters;
 		Gases = gases;
 	}
 

--- a/NtoLib/ConfigLoader/Io/Default/DefaultConfigurationFactory.cs
+++ b/NtoLib/ConfigLoader/Io/Default/DefaultConfigurationFactory.cs
@@ -10,7 +10,7 @@ public static class DefaultConfigurationFactory
 			CreateEmptyArray(groups.Shutters.Capacity),
 			CreateEmptyArray(groups.Sources.Capacity),
 			CreateEmptyArray(groups.ChamberHeaters.Capacity),
-			CreateEmptyArray(groups.Water.Capacity),
+			CreateEmptyArray(groups.Waters.Capacity),
 			CreateEmptyArray(groups.Gases.Capacity));
 	}
 

--- a/NtoLib/ConfigLoader/Io/FileLoader.cs
+++ b/NtoLib/ConfigLoader/Io/FileLoader.cs
@@ -26,7 +26,7 @@ public class FileLoader
 			groups.Shutters.Capacity,
 			groups.Sources.Capacity,
 			groups.ChamberHeaters.Capacity,
-			groups.Water.Capacity,
+			groups.Waters.Capacity,
 			groups.Gases.Capacity);
 	}
 

--- a/NtoLib/ConfigLoader/Io/FileSaver.cs
+++ b/NtoLib/ConfigLoader/Io/FileSaver.cs
@@ -31,7 +31,7 @@ public class FileSaver
 			groups.Shutters.Capacity,
 			groups.Sources.Capacity,
 			groups.ChamberHeaters.Capacity,
-			groups.Water.Capacity,
+			groups.Waters.Capacity,
 			groups.Gases.Capacity);
 	}
 
@@ -58,7 +58,7 @@ public class FileSaver
 			BuildDictionary(dto.Shutters),
 			BuildDictionary(dto.Sources),
 			BuildDictionary(dto.ChamberHeaters),
-			BuildDictionary(dto.WaterChannels),
+			BuildDictionary(dto.Waters),
 			BuildDictionary(dto.Gases));
 
 		var validateResult = _validator.ValidateAndMap(yamlConfig);

--- a/NtoLib/ConfigLoader/Pins/PinGroupManager.cs
+++ b/NtoLib/ConfigLoader/Pins/PinGroupManager.cs
@@ -15,17 +15,17 @@ public class PinGroupManager
 	private const int PinOffsetInsideGroup = 1;
 	private readonly StaticFBBase _fb;
 	private readonly ConfigLoaderGroups _groups;
-	private int _firstChamberHeaterInPinId;
-	private int _firstChamberHeaterOutPinId;
+	private int _firstChamberHeatersInPinId;
+	private int _firstChamberHeatersOutPinId;
 	private int _firstGasesInPinId;
 	private int _firstGasesOutPinId;
 
-	private int _firstShutterInPinId;
-	private int _firstShutterOutPinId;
+	private int _firstShuttersInPinId;
+	private int _firstShuttersOutPinId;
 	private int _firstSourcesInPinId;
 	private int _firstSourcesOutPinId;
-	private int _firstWaterInPinId;
-	private int _firstWaterOutPinId;
+	private int _firstWatersInPinId;
+	private int _firstWatersOutPinId;
 
 	public PinGroupManager(StaticFBBase fb, ConfigLoaderGroups groups)
 	{
@@ -41,8 +41,8 @@ public class PinGroupManager
 			_groups.Shutters.InBaseId,
 			_groups.Shutters.OutBaseId,
 			_groups.Shutters.Capacity,
-			out _firstShutterInPinId,
-			out _firstShutterOutPinId);
+			out _firstShuttersInPinId,
+			out _firstShuttersOutPinId);
 
 		CreatePinGroup(
 			_groups.Sources.Name,
@@ -59,17 +59,17 @@ public class PinGroupManager
 			_groups.ChamberHeaters.InBaseId,
 			_groups.ChamberHeaters.OutBaseId,
 			_groups.ChamberHeaters.Capacity,
-			out _firstChamberHeaterInPinId,
-			out _firstChamberHeaterOutPinId);
+			out _firstChamberHeatersInPinId,
+			out _firstChamberHeatersOutPinId);
 
 		CreatePinGroup(
-			_groups.Water.Name,
-			_groups.Water.YamlSection,
-			_groups.Water.InBaseId,
-			_groups.Water.OutBaseId,
-			_groups.Water.Capacity,
-			out _firstWaterInPinId,
-			out _firstWaterOutPinId);
+			_groups.Waters.Name,
+			_groups.Waters.YamlSection,
+			_groups.Waters.InBaseId,
+			_groups.Waters.OutBaseId,
+			_groups.Waters.Capacity,
+			out _firstWatersInPinId,
+			out _firstWatersOutPinId);
 
 		CreatePinGroup(
 			_groups.Gases.Name,
@@ -83,10 +83,10 @@ public class PinGroupManager
 
 	public LoaderDto ReadInputPins()
 	{
-		var shutters = ReadPinGroupValues(_firstShutterInPinId, _groups.Shutters.Capacity);
+		var shutters = ReadPinGroupValues(_firstShuttersInPinId, _groups.Shutters.Capacity);
 		var sources = ReadPinGroupValues(_firstSourcesInPinId, _groups.Sources.Capacity);
-		var chamberHeaters = ReadPinGroupValues(_firstChamberHeaterInPinId, _groups.ChamberHeaters.Capacity);
-		var waters = ReadPinGroupValues(_firstWaterInPinId, _groups.Water.Capacity);
+		var chamberHeaters = ReadPinGroupValues(_firstChamberHeatersInPinId, _groups.ChamberHeaters.Capacity);
+		var waters = ReadPinGroupValues(_firstWatersInPinId, _groups.Waters.Capacity);
 		var gases = ReadPinGroupValues(_firstGasesInPinId, _groups.Gases.Capacity);
 
 		return new LoaderDto(shutters, sources, chamberHeaters, waters, gases);
@@ -94,10 +94,10 @@ public class PinGroupManager
 
 	public void WriteOutputPins(LoaderDto dto)
 	{
-		WritePinGroupValues(_firstShutterOutPinId, dto.Shutters);
+		WritePinGroupValues(_firstShuttersOutPinId, dto.Shutters);
 		WritePinGroupValues(_firstSourcesOutPinId, dto.Sources);
-		WritePinGroupValues(_firstChamberHeaterOutPinId, dto.ChamberHeaters);
-		WritePinGroupValues(_firstWaterOutPinId, dto.WaterChannels);
+		WritePinGroupValues(_firstChamberHeatersOutPinId, dto.ChamberHeaters);
+		WritePinGroupValues(_firstWatersOutPinId, dto.Waters);
 		WritePinGroupValues(_firstGasesOutPinId, dto.Gases);
 	}
 

--- a/NtoLib/ConfigLoader/Yaml/YamlSerializer.cs
+++ b/NtoLib/ConfigLoader/Yaml/YamlSerializer.cs
@@ -23,13 +23,13 @@ public class YamlSerializer
 
 	public Result<string> Serialize(LoaderDto dto)
 	{
-		var shutter = BuildDictionary(dto.Shutters);
-		var source = BuildDictionary(dto.Sources);
-		var chamberHeater = BuildDictionary(dto.ChamberHeaters);
-		var water = BuildDictionary(dto.WaterChannels);
+		var shutters = BuildDictionary(dto.Shutters);
+		var sources = BuildDictionary(dto.Sources);
+		var chamberHeaters = BuildDictionary(dto.ChamberHeaters);
+		var waters = BuildDictionary(dto.Waters);
 		var gases = BuildDictionary(dto.Gases);
 
-		var yamlConfig = new YamlConfigDto(shutter, source, chamberHeater, water, gases);
+		var yamlConfig = new YamlConfigDto(shutters, sources, chamberHeaters, waters, gases);
 
 		var yaml = _serializer.Serialize(yamlConfig);
 

--- a/NtoLib/TrendPensManager/Services/ServiceFilter.cs
+++ b/NtoLib/TrendPensManager/Services/ServiceFilter.cs
@@ -14,7 +14,7 @@ public sealed class ServiceFilter
 		};
 
 	private static readonly HashSet<string>
-		_vacuumMetersNames = new(StringComparer.OrdinalIgnoreCase) { "Вакуумметры" };
+		_vacuumMeterNames = new(StringComparer.OrdinalIgnoreCase) { "Вакуумметры" };
 
 	private static readonly HashSet<string> _pyrometerNames = new(StringComparer.OrdinalIgnoreCase) { "Пирометр" };
 
@@ -66,7 +66,7 @@ public sealed class ServiceFilter
 			return IsKnownServiceTypeEnabled(knownType, options);
 		}
 
-		if (_vacuumMetersNames.Contains(serviceName))
+		if (_vacuumMeterNames.Contains(serviceName))
 		{
 			return options.AddVacuumMeters;
 		}

--- a/Tests/ConfigLoader/Integration/EdgeCaseTests.cs
+++ b/Tests/ConfigLoader/Integration/EdgeCaseTests.cs
@@ -121,7 +121,7 @@ public sealed class EdgeCaseTests
 		{
 			service.CurrentConfiguration.Shutters[i].Should().Be($"Shutter{i + 1}");
 			service.CurrentConfiguration.ChamberHeaters[i].Should().Be($"Heater{i + 1}");
-			service.CurrentConfiguration.WaterChannels[i].Should().Be($"Water{i + 1}");
+			service.CurrentConfiguration.Waters[i].Should().Be($"Water{i + 1}");
 		}
 
 		for (var i = 0; i < 32; i++)
@@ -140,7 +140,7 @@ public sealed class EdgeCaseTests
 		dto.Shutters.Length.Should().Be(16);
 		dto.Sources.Length.Should().Be(32);
 		dto.ChamberHeaters.Length.Should().Be(16);
-		dto.WaterChannels.Length.Should().Be(16);
+		dto.Waters.Length.Should().Be(16);
 	}
 
 	[Fact]

--- a/Tests/ConfigLoader/Integration/RoundTripTests.cs
+++ b/Tests/ConfigLoader/Integration/RoundTripTests.cs
@@ -29,7 +29,7 @@ public sealed class RoundTripTests
 		service.CurrentConfiguration.Shutters[1].Should().Be("Another Shutter");
 		service.CurrentConfiguration.Sources[0].Should().Be("Source-1");
 		service.CurrentConfiguration.ChamberHeaters[0].Should().Be("Heater.1");
-		service.CurrentConfiguration.WaterChannels[0].Should().Be("Water_Pump");
+		service.CurrentConfiguration.Waters[0].Should().Be("Water_Pump");
 	}
 
 	[Fact]
@@ -47,7 +47,7 @@ public sealed class RoundTripTests
 		service.CurrentConfiguration.Shutters.Should().AllBe(string.Empty);
 		service.CurrentConfiguration.Sources.Should().AllBe(string.Empty);
 		service.CurrentConfiguration.ChamberHeaters.Should().AllBe(string.Empty);
-		service.CurrentConfiguration.WaterChannels.Should().AllBe(string.Empty);
+		service.CurrentConfiguration.Waters.Should().AllBe(string.Empty);
 	}
 
 	[Fact]

--- a/Tests/ConfigLoader/Integration/SaveTests.cs
+++ b/Tests/ConfigLoader/Integration/SaveTests.cs
@@ -96,9 +96,9 @@ public sealed class SaveTests
 		{
 			dto.ChamberHeaters[i] = "";
 		}
-		for (var i = 0; i < dto.WaterChannels.Length; i++)
+		for (var i = 0; i < dto.Waters.Length; i++)
 		{
-			dto.WaterChannels[i] = "";
+			dto.Waters[i] = "";
 		}
 
 		var result = service.Save(filePath, dto);

--- a/Tests/ConfigLoader/Integration/ServiceStateTests.cs
+++ b/Tests/ConfigLoader/Integration/ServiceStateTests.cs
@@ -35,7 +35,7 @@ public sealed class ServiceStateTests
 		service.CurrentConfiguration.Shutters.Should().AllBe(string.Empty);
 		service.CurrentConfiguration.Sources.Should().AllBe(string.Empty);
 		service.CurrentConfiguration.ChamberHeaters.Should().AllBe(string.Empty);
-		service.CurrentConfiguration.WaterChannels.Should().AllBe(string.Empty);
+		service.CurrentConfiguration.Waters.Should().AllBe(string.Empty);
 	}
 
 	[Fact]


### PR DESCRIPTION
## Что сделано

Тонкий неломающий срез унификации терминологии (#70): переименованы только идентификаторы, противоречащие друг другу внутри кодовой базы. Всё контрактное заморожено как легаси.

### Переименования

- `LoaderDto.WaterChannels` → `Waters` — один концепт имел два имени в пайплайне ConfigLoader (`Waters` в `YamlConfigDto`/`ConfigLoaderGroups`, `WaterChannels` в `LoaderDto`)
- `ConfigLoaderGroups`: параметр `Water` → `Waters` (строки в той же записи уже `"Waters"`)
- `YamlConfigDto`: параметры конструктора `shutter, chamberHeater, water` → множественное число (свойства уже были множественными)
- `PinGroupManager`: поля `_first*PinId` приведены к именам групп во множественном числе (`Gases`/`Sources` уже были, `Shutter`/`ChamberHeater`/`Water` — нет)
- `ServiceFilter`: `_vacuumMetersNames` → `_vacuumMeterNames` — единственное отклонение от singular compound adjunct в файле

### Скиллы

В `new-visual-fb` и `new-nonvisual-fb` добавлена секция «Naming conventions for domain entities»: канонические термины групп во множественном числе, правило «один концепт — один идентификатор», singular compound adjuncts, enum типа одного устройства — единственное число, идентификаторы контрактных строк следуют контракту, design-time свойства `[Serializable]` ФБ заморожены сериализацией.

### Что осознанно не тронуто

- Ключи YAML (`NamesConfig`, `PinGroupDefs`, `group_name`) — контракт кастомизированных конфигов заказчиков
- Имена пинов и узлов дерева — пути в проектах заказчиков (перья трендов, скрипты, `tree.json`)
- Свойства `TrendPensManagerFB` (`AddPyrometer`, `AddCryo`, ...) и зеркалящий их `ServiceSelectionOptions` — backing-поля сериализуются в проекты
- `PumpType` — тип одного насоса, единственное число корректно

Ядро (`Shutters`/`Sources`/`ChamberHeaters`/`Waters`/`Gases` в DTO и `NamesConfig.yaml`) уже было унифицировано ранее.

Сборка чистая, тесты 253/253.

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)