### PR TITLE
fix: удалить мёртвую регистрацию AddScoped<TableRenderCoordinator> (#108)

### DIFF
--- a/NtoLib/Recipes/MbeTable/ModuleInfrastructure/DiContainer.cs
+++ b/NtoLib/Recipes/MbeTable/ModuleInfrastructure/DiContainer.cs
@@ -335,7 +335,6 @@ public static class MbeTableServiceConfigurator
 		services.AddSingleton<ActionItemsProvider>();
 		services.AddSingleton<TargetItemsProvider>();
 		services.AddSingleton<ComboBoxCellRenderer>();
-		services.AddScoped<TableRenderCoordinator>();
 		services.AddSingleton<FactoryColumnRegistry>();
 		services.AddSingleton<TableControlServices>();
 


### PR DESCRIPTION
Closes #108. Завершает остаток issue: п.1 (Dispose координатора в `DisposeRuntimeComponents` обоих контролов) был закрыт в #112, здесь — п.2.

## Что сделано

Удалена мёртвая регистрация `services.AddScoped<TableRenderCoordinator>()` из `DiContainer.cs`.

## Обоснование безопасности удаления

- Резолва `TableRenderCoordinator` из контейнера не существует — координатор создаётся только через `ActivatorUtilities.CreateInstance` в обоих шеллах (`TableControl.Lifecycle.cs:108`, `MbeTableEditorControl.Lifecycle.cs:107`).
- `CreateScope()` в кодовой базе не вызывается ни разу — scoped-регистрация недостижима в принципе.
- `architecture.md` («Control-side composition») прямо фиксирует правило «do not register these types in the container» — правка приводит код в соответствие с документацией.
- Других регистраций UI-bound типов того же класса в контейнере нет — эта была единственной.

Поведение не меняется; рантайм-валидация в MasterSCADA не требуется. 290/290 тестов зелёные, `dotnet format` чистый.

🤖 Generated with [Claude Code](https://claude.com/claude-code)