### PR TITLE
fix: устранить CS8604 на пути конфигурации MbeTableFB

### DIFF
--- a/NtoLib/Recipes/MbeTable/MbeTableFB.Configuration.cs
+++ b/NtoLib/Recipes/MbeTable/MbeTableFB.Configuration.cs
@@ -39,7 +39,9 @@ public partial class MbeTableFB
 		// Backwards compatibility: projects saved before the ConfigDirPath property existed (#67)
 		// deserialize with a null field, and a manually blanked property must not reach
 		// Path.Combine as a relative path. Both fall back to the pre-#67 location.
-		if (string.IsNullOrWhiteSpace(_configDirPath))
+		// The explicit null check narrows the compiler's null-state: net48 mscorlib has no
+		// [NotNullWhen(false)] on IsNullOrWhiteSpace, so the call alone would not.
+		if (_configDirPath is null || string.IsNullOrWhiteSpace(_configDirPath))
 		{
 			_configDirPath = Path.Combine(AppContext.BaseDirectory, DefaultConfigFolderName);
 		}


### PR DESCRIPTION
Хвост #110/#115: расширение условия фолбэка до `IsNullOrWhiteSpace` ввело предупреждение `CS8604` — на net48 mscorlib нет `[NotNullWhen(false)]` на `IsNullOrWhiteSpace`, и null-state-анализ не сужается guard'ом. В сборках #115 предупреждение не было замечено из-за инкрементальности (компиляция не перезапускалась, сводка показывала ноль предупреждений); CI собирает начисто и предупреждение показал.

## Что сделано

Явная проверка `_configDirPath is null` первым дизъюнктом условия — обучает анализатор без оператора подавления `!`. Порядок выбран намеренно: первый дизъюнкт выполняется в рантайме и не помечается Rider'ом как «always false» (в обратном порядке Code Cleanup снёс бы его как избыточный, вернув предупреждение). Комментарий в коде фиксирует причину, чтобы проверку не упростили обратно.

Рантайм-поведение не меняется: `IsNullOrWhiteSpace(null)` и так возвращает true.

## Проверка

`dotnet build --no-incremental` обеих конфигураций: 0 предупреждений CS. 293/293 теста, формат чистый.

🤖 Generated with [Claude Code](https://claude.com/claude-code)